### PR TITLE
Version 1.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# CHANGELOG for LaunchKey Java SDK
+
+This changelog references the relevant changes (bug and security fixes) for the lifetime of the library.
+
+To get the diff for a specific change, go to [https://github.com/LaunchKey/launchkey-java/commit/XXX](https://github.com/LaunchKey/launchkey-java/commit/XXX) where XXX
+is the change hash To get the diff between two versions, go to
+[https://github.com/LaunchKey/launchkey-java/compare/launchkey-sdk-1.0.0...launchkey-sdk-1.1.0](https://github.com/LaunchKey/launchkey-java/compare/launchkey-sdk-1.0.0...launchkey-sdk-1.1.0)
+
+  * 1.0.0
+    * First release with authentication methods
+
+  * 1.1.0
+    * Added white label user create method
+    * Loosened restrictions on dependency versions
+    * Refactored to use non-deprecated methods for Apache HTTP client
+    * Added ability to connect to staging servers for pre-release testing
+    * Fixed bug in authentication manager that would error looking for a user_push_id response attribute when login call
+        specified false for userPushId parameter

--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ __Due to the number of dependencies required by the LaunchKey SDK, it would be b
         }
 
         ```
+        
+    * Add a white label user
+
+        ```java
+        try {
+            authenticationManager.createWhiteLabelUser(myUniqueUserIdentifier);
+            
+            // Show the user the QR Code from the QR Code URL to be validated in a white label application
+        }
+        catch(AuthenticationException e) {
+           //error handling
+        }
+
+        ```
 
 #  <a name="support"></a>Support
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.0.3</version>
+            <version>[4.3,4.4)</version>
         </dependency>
 
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.8</version>
+            <version>[1.7,2.0)</version>
         </dependency>
 
         <dependency>
@@ -76,6 +76,7 @@
             <scope>test</scope>
         </dependency>
 
+        
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/src/main/java/com/launchkey/sdk/auth/UserCreationException.java
+++ b/src/main/java/com/launchkey/sdk/auth/UserCreationException.java
@@ -1,0 +1,24 @@
+package com.launchkey.sdk.auth;
+
+/**
+ * Copyright (C) 2015 LaunchKey, Inc. All Rights Reserved.
+ *
+ * @author Adam Englander <adam@launchkey.com>
+ */
+public class UserCreationException extends Exception {
+    private final String code;
+
+    public UserCreationException(String message, String code) {
+        super(message);
+        this.code = code;
+    }
+
+    public UserCreationException(String message, Throwable throwable, String code) {
+        super(message, throwable);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/launchkey/sdk/auth/WhiteLabelUserCreateResult.java
+++ b/src/main/java/com/launchkey/sdk/auth/WhiteLabelUserCreateResult.java
@@ -1,0 +1,56 @@
+package com.launchkey.sdk.auth;
+
+/**
+ * Copyright (C) 2015 LaunchKey, Inc. All Rights Reserved.
+ *
+ * @author Adam Englander <adam@launchkey.com>
+ */
+public class WhiteLabelUserCreateResult {
+    /**
+     *  The URL to a QR Code for the device to scan
+     */
+    private String qrCodeUrl;
+
+    /**
+     *  The value to store in order to push future requests to this user
+     */
+    private String launchKeyIdentifier;
+
+    /**
+     * Code for the user to type into their device for manual verification if they are unable to scan the QR Code
+     */
+    private String code;
+
+    /**
+     * @param qrCodeUrl The URL to a QR Code for the device to scan
+     * @param launchKeyIdentifier The value to store in order to push future requests to this user
+     * @param code Code for the user to type into their device for manual verification if they are unable to scan the
+     *             QR Code
+     */
+    public WhiteLabelUserCreateResult(String qrCodeUrl, String launchKeyIdentifier, String code) {
+        this.qrCodeUrl = qrCodeUrl;
+        this.launchKeyIdentifier = launchKeyIdentifier;
+        this.code = code;
+    }
+
+    /**
+     * @return The URL to a QR Code for the device to scan
+     */
+    public String getQrCodeUrl() {
+        return qrCodeUrl;
+    }
+
+    /**
+     * @return The value to store in order to push future requests to this user
+     */
+    public String getLaunchKeyIdentifier() {
+        return launchKeyIdentifier;
+    }
+
+    /**
+     * @return Code for the user to type into their device for manual verification if they are unable to scan the QR Code
+     */
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/launchkey/sdk/http/AuthController.java
+++ b/src/main/java/com/launchkey/sdk/http/AuthController.java
@@ -19,14 +19,19 @@ public class AuthController extends HttpController implements AuthControllerInte
     private static final String AUTHS_PATH = "/auths";
     private static final String LOGS_PATH = "/logs";
     private static final String POLL_PATH = "/poll";
+    private static final String USERS_PATH = "/users";
 
     public AuthController(HttpClient httpClient) {
         super(httpClient);
     }
 
+    public AuthController(HttpClient httpClient, boolean isStaging) {
+        super(httpClient, isStaging);
+    }
+
     @Override
     public JSONResponse pingGet() {
-        StringBuilder url = new StringBuilder(SERVER_URL);
+        StringBuilder url = new StringBuilder(this.serverUrl);
         url.append(PING_PATH);
         HttpGet get = new HttpGet(url.toString());
         try {
@@ -39,7 +44,7 @@ public class AuthController extends HttpController implements AuthControllerInte
 
     @Override
     public JSONResponse authsPost(String launchKeyTime, String publicKey, String userName, boolean session, boolean userPushId) {
-        StringBuilder url = new StringBuilder(SERVER_URL);
+        StringBuilder url = new StringBuilder(this.serverUrl);
         url.append(AUTHS_PATH);
         HttpPost post = new HttpPost(url.toString());
         try {
@@ -59,7 +64,7 @@ public class AuthController extends HttpController implements AuthControllerInte
     @Override
     public JSONResponse pollGet(String launchKeyTime, String publicKey, String authRequest) {
         try {
-            StringBuilder url = new StringBuilder(SERVER_URL);
+            StringBuilder url = new StringBuilder(this.serverUrl);
             url.append(POLL_PATH);
             ArrayList<NameValuePair> params = this.defaultPostParams(launchKeyTime, publicKey);
             params.add(new BasicNameValuePair("auth_request", authRequest));
@@ -74,7 +79,7 @@ public class AuthController extends HttpController implements AuthControllerInte
 
     @Override
     public JSONResponse logsPut(String authRequest, String launchKeyTime, String publicKey, String action, boolean status) {
-        StringBuilder url = new StringBuilder(SERVER_URL);
+        StringBuilder url = new StringBuilder(this.serverUrl);
         url.append(LOGS_PATH);
         HttpPut put = new HttpPut(url.toString());
         try {
@@ -88,6 +93,24 @@ public class AuthController extends HttpController implements AuthControllerInte
         catch(Exception e) {
             return getErrorResponse(e);
         }
+    }
+    
+    @Override
+    public JSONResponse usersPost(String launchKeyTime, String publicKey, String identifier) {
+        StringBuilder url = new StringBuilder(this.serverUrl);
+        url.append(USERS_PATH);
+        HttpPost post = new HttpPost(url.toString());
+
+        JSONResponse response;
+        try {
+            ArrayList<NameValuePair> params = this.defaultPostParams(launchKeyTime, publicKey);
+            params.add(new BasicNameValuePair("identifier", identifier));
+            post.setEntity(new UrlEncodedFormEntity(params, HTTP.UTF_8));
+            response = httpClient.execute(post, new JSONResponseHandler());
+        } catch (Exception e) {
+            response = getErrorResponse(e);
+        }
+        return response;
     }
 
     private static JSONResponse getErrorResponse(Exception e) {

--- a/src/main/java/com/launchkey/sdk/http/AuthControllerInterface.java
+++ b/src/main/java/com/launchkey/sdk/http/AuthControllerInterface.java
@@ -12,6 +12,20 @@ public interface AuthControllerInterface {
 
     JSONResponse logsPut(String authRequest, String launchKeyTime, String publicKey, String action, boolean status);
 
+    /**
+     * Create a LaunchKey user
+     *  
+     * @param launchKeyTime LaunchKey time from the most recent poll request
+     * @param publicKey LaunchKey pubic key from the most recent poll request
+     * @param identifier How the user is identified to your application. This should be a static value such as a
+     * user's ID or UUID value rather than an email address which may be subject to change
+     * @return JSON response whose JSONObject contains the following on success:
+     *    qrcode - The URL to a QR Code for the device to scan
+     *    lk_identifier - The value to store in order to push future requests to this user
+     *    code - Manual code for the user to type into their device if they are unable to scan the QR Code
+     */
+    JSONResponse usersPost(String launchKeyTime, String publicKey, String identifier);
+
     void setAppKey(String appKey);
 
     String getAppKey();

--- a/src/main/java/com/launchkey/sdk/http/HttpClientFactory.java
+++ b/src/main/java/com/launchkey/sdk/http/HttpClientFactory.java
@@ -1,36 +1,18 @@
 package com.launchkey.sdk.http;
 
-import org.apache.http.HttpHost;
 import org.apache.http.client.HttpClient;
-import org.apache.http.conn.params.ConnManagerParams;
-import org.apache.http.conn.params.ConnPerRouteBean;
-import org.apache.http.conn.routing.HttpRoute;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpParams;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 public class HttpClientFactory {
-    private int maxConnections;
+    private Integer maxConnections;
 
     public HttpClient createClient() {
-        SchemeRegistry schemeRegistry = new SchemeRegistry();
-        schemeRegistry.register(
-                new Scheme("https", SSLSocketFactory.getSocketFactory(), 443));
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        if (maxConnections != null) {
+            builder.setMaxConnPerRoute(maxConnections);
+        }
 
-        HttpParams params = new BasicHttpParams();
-        ConnManagerParams.setMaxTotalConnections(params, this.maxConnections);
-        ConnPerRouteBean connPerRoute = new ConnPerRouteBean();
-        HttpHost host = new HttpHost("api.launchkey.com");
-        connPerRoute.setMaxForRoute(new HttpRoute(host), 200);
-        ConnManagerParams.setMaxConnectionsPerRoute(params, connPerRoute);
-
-        ThreadSafeClientConnManager threadSafeClientConnManager = new ThreadSafeClientConnManager(params, schemeRegistry);
-
-        return new DefaultHttpClient(threadSafeClientConnManager, params);
+        return builder.build();
     }
 
     public int getMaxConnections() {

--- a/src/main/java/com/launchkey/sdk/http/HttpController.java
+++ b/src/main/java/com/launchkey/sdk/http/HttpController.java
@@ -21,15 +21,22 @@ import java.util.logging.Logger;
 public class HttpController {
     private static final Logger LOG = Logger.getLogger(HttpController.class.getName());
 
-    protected static final String SERVER_URL = "https://api.launchkey.com/v1";
+    protected static final String PROD_SERVER_URL = "https://api.launchkey.com/v1";
+    protected static final String STAGING_SERVER_URL = "https://staging-api.launchkey.com/v1";
 
     protected final HttpClient httpClient;
+    protected final String serverUrl;
     protected String appKey;
     protected String secretKey;
     protected String privateKey;
 
     public HttpController(HttpClient httpClient) {
+        this(httpClient, false);
+    }
+
+    public HttpController(HttpClient httpClient, boolean isStaging) {
         this.httpClient = httpClient;
+        serverUrl = isStaging ? STAGING_SERVER_URL : PROD_SERVER_URL;
     }
 
     protected static final class JSONCallbackResponseHandler implements ResponseHandler<Integer> {

--- a/src/test/java/com/launchkey/sdk/auth/UserCreationExceptionTest.java
+++ b/src/test/java/com/launchkey/sdk/auth/UserCreationExceptionTest.java
@@ -1,0 +1,38 @@
+package com.launchkey.sdk.auth;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UserCreationExceptionTest {
+    @Test
+    public void testMessageCodeConstructorSetsMessage() throws Exception {
+        UserCreationException ex = new UserCreationException("expected", "1111");
+        assertEquals("expected", ex.getMessage());
+    }
+
+    @Test
+    public void testMessageCodeConstructorSetsCode() throws Exception {
+        UserCreationException ex = new UserCreationException("expected", "1111");
+        assertEquals("1111", ex.getCode());
+    }
+
+    @Test
+    public void testMessageCauseCodeSetsMessage() throws Exception {
+        UserCreationException ex = new UserCreationException("expected", new Exception(), "1111");
+        assertEquals("expected", ex.getMessage());
+    }
+
+    @Test
+    public void testMessageCauseCodeSetsThrowable() throws Exception {
+        Exception expected = new Exception();
+        UserCreationException ex = new UserCreationException("expected", expected, "1111");
+        assertSame(expected, ex.getCause());
+    }
+
+    @Test
+    public void testMessageCauseCodeSetsCode() throws Exception {
+        UserCreationException ex = new UserCreationException("expected", new Exception(), "1111");
+        assertEquals("1111", ex.getCode());
+    }
+}

--- a/src/test/java/com/launchkey/sdk/auth/WhiteLabelUserCreateResultTest.java
+++ b/src/test/java/com/launchkey/sdk/auth/WhiteLabelUserCreateResultTest.java
@@ -1,0 +1,29 @@
+package com.launchkey.sdk.auth;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class WhiteLabelUserCreateResultTest {
+
+    @Test
+    public void testGetQrCodeUrl() throws Exception {
+        String expected = "expected";
+        WhiteLabelUserCreateResult result = new WhiteLabelUserCreateResult(expected, null, null);
+        assertEquals(expected, result.getQrCodeUrl());
+    }
+
+    @Test
+    public void testGetLaunchKeyIdentifier() throws Exception {
+        String expected = "expected";
+        WhiteLabelUserCreateResult result = new WhiteLabelUserCreateResult(null, expected, null);
+        assertEquals(expected, result.getLaunchKeyIdentifier());
+    }
+
+    @Test
+    public void testGetCode() throws Exception {
+        String expected = "expected";
+        WhiteLabelUserCreateResult result = new WhiteLabelUserCreateResult(null, null, expected);
+        assertEquals(expected, result.getCode());
+    }
+}

--- a/src/test/java/com/launchkey/sdk/crypto/CryptoTest.java
+++ b/src/test/java/com/launchkey/sdk/crypto/CryptoTest.java
@@ -2,8 +2,6 @@ package com.launchkey.sdk.crypto;
 
 import com.launchkey.sdk.TestAbstract;
 import com.launchkey.sdk.Util;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.digest.Crypt;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/src/test/java/com/launchkey/sdk/http/HttpClientFactoryTest.java
+++ b/src/test/java/com/launchkey/sdk/http/HttpClientFactoryTest.java
@@ -5,6 +5,7 @@ import org.apache.http.conn.params.ConnManagerPNames;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 import static org.junit.Assert.*;
 
@@ -28,23 +29,15 @@ public class HttpClientFactoryTest {
     }
 
     @Test
-    public void testCreateClientUsesHttps() throws Exception {
-        assertNotNull(
-            "https not registered in schema registry",
-            httpClient.getConnectionManager().getSchemeRegistry().getScheme("https")
-        );
-    }
-
-    @Test
-    public void testCreateClientUsesMaxConnections() throws Exception {
-        int actual = httpClient.getParams().getIntParameter(ConnManagerPNames.MAX_TOTAL_CONNECTIONS, 0);
-        assertEquals(100, actual);
-    }
-
-    @Test
     public void testSetGetMaxConnections() throws Exception {
         int expected = 666;
         httpClientFactory.setMaxConnections(expected);
         assertEquals(expected, httpClientFactory.getMaxConnections());
+    }
+
+    @Test
+    public void testCreateClientReturnsClient() throws Exception {
+        HttpClient client = httpClientFactory.createClient();
+        assertThat(client, instanceOf(HttpClient.class));
     }
 }


### PR DESCRIPTION
Add create user functionality for white label
Loosened restrictions on dependency versions
Refactored to use non-deprecated methods for Apache HTTP client
Added ability to connect to staging servers for pre-release testing
Fixed bug in authentication manager that would error looking for a user_push_id response attribute when login call specified false for userPushId parameter