### PR TITLE
Improve JCECrypto.getKeyBytesFromPEM()

### DIFF
--- a/sdk/src/main/java/com/launchkey/sdk/crypto/JCECrypto.java
+++ b/sdk/src/main/java/com/launchkey/sdk/crypto/JCECrypto.java
@@ -24,6 +24,8 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Scanner;
+
 import org.apache.commons.codec.binary.Base64;
 
 /**
@@ -191,8 +193,10 @@ public class JCECrypto implements Crypto {
     }
 
     private static byte[] getKeyBytesFromPEM(String pem) {
-        StringBuilder strippedKey = new StringBuilder();
-        for(String line : pem.split("\n")) {
+        StringBuilder strippedKey = new StringBuilder(pem.length());
+        Scanner scanner = new Scanner(pem);
+        while(scanner.hasNextLine()) {
+            String line = scanner.nextLine();
             if(!line.matches(".*(BEGIN|END) (RSA )?(PUBLIC|PRIVATE) KEY.*")) {
                 strippedKey.append(line.trim());
             }

--- a/sdk/src/test/java/com/launchkey/sdk/crypto/JCECryptoTest.java
+++ b/sdk/src/test/java/com/launchkey/sdk/crypto/JCECryptoTest.java
@@ -52,6 +52,11 @@ public class JCECryptoTest {
                     "Ud+Zy3E0RJXToW0t3Eo5UexVieglvpgxG7x1SCdvxYtTl6CZ520=\n" +
                     "-----END RSA PRIVATE KEY-----\n");
 
+
+
+    private static final String PRIVATE_KEY_CARRIAGE_RETURN = PRIVATE_KEY.replace('\n', '\r');
+    private static final String PRIVATE_KEY_CARRIAGE_RETURN_NEWLINE = PRIVATE_KEY.replace("\n", "\r\n");
+
     private static final String PUBLIC_KEY =
             ("-----BEGIN RSA PUBLIC KEY-----\n" +
                     "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq2izh7NEarDdrdZLrpli\n" +
@@ -62,6 +67,9 @@ public class JCECryptoTest {
                     "ac4AlR80AEaBeiuFYxjHpruS6BRcyW8UvqX0l9rKMDAWNAtMWt2egYAe6XOEXIWO\n" +
                     "iQIDAQAB\n" +
                     "-----END RSA PUBLIC KEY-----\n");
+
+    private static final String PUBLIC_KEY_CARRIAGE_RETURN = PUBLIC_KEY.replace('\n', '\r');
+    private static final String PUBLIC_KEY_CARRIAGE_RETURN_NEWLINE = PUBLIC_KEY.replace("\n", "\r\n");
 
     private Base64 base64;
     private BouncyCastleProvider provider;
@@ -194,8 +202,32 @@ public class JCECryptoTest {
     }
 
     @Test
+    public void testGetRSAPublicKeyFromPEM_CarriageReturn() throws Exception {
+        RSAPublicKey actual = JCECrypto.getRSAPublicKeyFromPEM(provider, PUBLIC_KEY_CARRIAGE_RETURN);
+        assertNotNull(actual);
+    }
+
+    @Test
+    public void testGetRSAPublicKeyFromPEM_CarriageReturnNewline() throws Exception {
+        RSAPublicKey actual = JCECrypto.getRSAPublicKeyFromPEM(provider, PUBLIC_KEY_CARRIAGE_RETURN_NEWLINE);
+        assertNotNull(actual);
+    }
+
+    @Test
     public void testGetRSAPrivateKeyFromPEM() throws Exception {
         RSAPrivateKey actual = JCECrypto.getRSAPrivateKeyFromPEM(provider, PRIVATE_KEY);
+        assertNotNull(actual);
+    }
+
+    @Test
+    public void testGetRSAPrivateKeyFromPEM_CarriageReturn() throws Exception {
+        RSAPrivateKey actual = JCECrypto.getRSAPrivateKeyFromPEM(provider, PRIVATE_KEY_CARRIAGE_RETURN);
+        assertNotNull(actual);
+    }
+
+    @Test
+    public void testGetRSAPrivateKeyFromPEM_CarriageReturnNewline() throws Exception {
+        RSAPrivateKey actual = JCECrypto.getRSAPrivateKeyFromPEM(provider, PRIVATE_KEY_CARRIAGE_RETURN_NEWLINE);
         assertNotNull(actual);
     }
 }


### PR DESCRIPTION
I updated JCECrypto.getKeyBytesFromPEM() to use a java.util.Scanner to split the lines.  This will make the method work for PEM strings whose line terminators include "\r" and "\r\n" as well as "\n".